### PR TITLE
normalize ci, allow test failures outside main.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,6 +60,7 @@ stages:
       displayName: dotnet build
       workingDirectory: $(targetSolution)
 
+    # test on main or PRs to main
     - task: DotNetCoreCLI@2
       displayName: dotnet test (failures disallowed)
       condition: and(succeeded(), in('refs/heads/main', variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch']))
@@ -69,6 +70,8 @@ stages:
         publishTestResults: true
         workingDirectory: '$(targetSolution)'
 
+    # test outside on main or PRs to main
+    # (fails allowed for TDD workflow)
     - task: DotNetCoreCLI@2
       displayName: dotnet test (failures allowed)
       condition: and(succeeded(), notIn('refs/heads/main', variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch']))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,6 +60,7 @@ stages:
       displayName: dotnet build
       workingDirectory: $(targetSolution)
 
+    # if previous steps successful, exactly one of these two steps should run:
     # test on main or PRs to main
     - task: DotNetCoreCLI@2
       displayName: dotnet test (failures disallowed)
@@ -71,7 +72,7 @@ stages:
         workingDirectory: '$(targetSolution)'
 
     # test outside of main or PRs to main
-    # (fails allowed for TDD workflow)
+    # (identical except: fails allowed for TDD workflow)
     - task: DotNetCoreCLI@2
       displayName: dotnet test (failures allowed)
       condition: and(succeeded(), notIn('refs/heads/main', variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch']))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,87 +1,103 @@
+# trigger on main push
 trigger:
   branches:
     include:
     - main
-
   paths:
     include:
     - azure-pipelines.yml
-    - 'Fakebook.Profile'
+    - Fakebook.Profile
 
 pr:
   branches:
     include:
     - '*'
-
   paths:
     include:
     - azure-pipelines.yml
-    - 'Fakebook.Profile'
+    - Fakebook.Profile
 
 pool:
-  vmImage: 'ubuntu-latest'
+  vmImage: ubuntu-latest
 
 variables:
-  sdkVersion: '5.x'
-  buildConfiguration: 'Release'
-  targetProject: 'Fakebook.Profile/Fakebook.Profile.RestApi'
-  targetSolution: 'Fakebook.Profile'
+  targetSolution: Fakebook.Profile
 
 stages:
 - stage: analyze
+  variables:
+    buildConfiguration: Release
   jobs:
   - job: build
     steps:
+    # use .net core 2 for sonar compatibility
     - task: UseDotNet@2
-      displayName: dotnet sdk 2.x
+      displayName: dotnet sdk 2
       inputs:
         packageType: 'sdk'
         version: '2.x'
 
     - task: SonarCloudPrepare@1
+      displayName: sonar prepare analysis
       inputs:
         SonarCloud: 'SonarCloud Token'
         organization: '2011-fakebook-project3'
         scannerMode: 'MSBuild'
         projectKey: '2011-fakebook-project3_profile'
         projectName: 'profile'
-        extraProperties: 'sonar.cs.opencover.reportsPaths=$(Agent.TempDirectory)/**/coverage.opencover.xml'
-        
+        extraProperties: |
+          sonar.cs.opencover.reportsPaths=$(Agent.TempDirectory)/**/coverage.opencover.xml
+          sonar.cs.vstest.reportsPaths=$(Agent.TempDirectory)/*.trx
+
+    # switch to .net 5
     - task: UseDotNet@2
-      displayName: 'Use .NET 5 SDK'
+      displayName: dotnet sdk 5
       inputs:
         packageType: 'sdk'
-        version: $(sdkVersion)
-        installationPath: $(Agent.ToolsDirectory)/dotnet
+        version: '5.x'
 
     - script: dotnet build --configuration $(buildConfiguration)
       displayName: dotnet build
       workingDirectory: $(targetSolution)
-        
+
     - task: DotNetCoreCLI@2
-      displayName: dotnet test
+      displayName: dotnet test (failures disallowed)
+      condition: and(succeeded(), in('refs/heads/main', variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch']))
       inputs:
         command: 'test'
-        arguments: '--configuration $(BuildConfiguration) --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover'
+        arguments: '--configuration $(buildConfiguration) --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover'
         publishTestResults: true
-        workingDirectory: 'Fakebook.Profile'
+        workingDirectory: '$(targetSolution)'
+
+    - task: DotNetCoreCLI@2
+      displayName: dotnet test (failures allowed)
+      condition: and(succeeded(), notIn('refs/heads/main', variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch']))
+      inputs:
+        command: 'test'
+        arguments: '--configuration $(buildConfiguration) --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover'
+        publishTestResults: true
+        workingDirectory: '$(targetSolution)'
 
     - task: SonarCloudAnalyze@1
       displayName: sonar run analysis
-      
+      condition: always()
+
     - task: SonarCloudPublish@1
       displayName: sonar analysis publish
+      condition: always()
       inputs:
         pollingTimeoutSec: '300'
 
 - stage: docker
   dependsOn: []
-  jobs: 
-  - job: docker
+  variables:
+    imageName: fakebookprofile
+  jobs:
+  - job: build
     steps:
     - task: Docker@2
       displayName: docker build image
       inputs:
-        repository: 'profile'
+        repository: '$(imageName)'
         command: 'build'
-        Dockerfile: '**/Dockerfile'
+        Dockerfile: '$(targetSolution)/Dockerfile'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,6 +72,7 @@ stages:
     - task: DotNetCoreCLI@2
       displayName: dotnet test (failures allowed)
       condition: and(succeeded(), notIn('refs/heads/main', variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch']))
+      continueOnError: true
       inputs:
         command: 'test'
         arguments: '--configuration $(buildConfiguration) --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,7 +70,7 @@ stages:
         publishTestResults: true
         workingDirectory: '$(targetSolution)'
 
-    # test outside on main or PRs to main
+    # test outside of main or PRs to main
     # (fails allowed for TDD workflow)
     - task: DotNetCoreCLI@2
       displayName: dotnet test (failures allowed)


### PR DESCRIPTION
cf. https://github.com/2011-fakebook-project3/notifications/pull/10, https://github.com/2011-fakebook-project3/posts/pull/26

docs on features used here
- https://docs.microsoft.com/en-us/azure/devops/pipelines/process/expressions
- https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables