### PR TITLE
Fixes for okta access and getting the blob container name

### DIFF
--- a/Fakebook.Profile/Fakebook.Profile.Domain/Utility/ProfileConfigOptions.cs
+++ b/Fakebook.Profile/Fakebook.Profile.Domain/Utility/ProfileConfigOptions.cs
@@ -5,8 +5,6 @@
     /// </summary>
     public class ProfileConfigOptions
     {
-        public const string ProfileConfig = "ProfileConfig";
-
-        public string BlobContainerName { get; set; }
+        public const string ProfileConfig = "ProfileConfig:BlobContainer";
     }
 }

--- a/Fakebook.Profile/Fakebook.Profile.RestApi/Controllers/ProfilePictureController.cs
+++ b/Fakebook.Profile/Fakebook.Profile.RestApi/Controllers/ProfilePictureController.cs
@@ -36,7 +36,7 @@ namespace Fakebook.Profile.RestApi.Controllers
         public ProfilePictureController(IStorageService storageService, ILogger<ProfileController> logger, IConfiguration configuration)
         {
             _logger = logger;
-            this._configuration = configuration;
+            _configuration = configuration;
             _storageService = storageService;
         }
 
@@ -58,22 +58,20 @@ namespace Fakebook.Profile.RestApi.Controllers
             }
 
             // generate a random guid from the file name
-            string extension = file
-                .FileName
+            string extension = file.FileName
                     .Split('.')
                     .Last();
             string newFileName = $"{Request.Form["userId"]}-{Guid.NewGuid()}.{extension}";
             _logger.LogInformation($"New file named to be uploaded, {newFileName}");
 
-            var profileConfigOptions = new ProfileConfigOptions();
-            _configuration.GetSection(ProfileConfigOptions.ProfileConfig).Bind(profileConfigOptions);
-
             // use the stream, and allow for it to close once this scope exits
             using var stream = file.OpenReadStream();
 
+            var containerName = _configuration[ProfileConfigOptions.ProfileConfig];
+
             var result = await _storageService.UploadFileContentAsync(
                 stream,
-                profileConfigOptions.BlobContainerName,
+                containerName,
                 file.ContentType,
                 newFileName);
 

--- a/Fakebook.Profile/Fakebook.Profile.RestApi/Startup.cs
+++ b/Fakebook.Profile/Fakebook.Profile.RestApi/Startup.cs
@@ -35,7 +35,7 @@ namespace Fakebook.Profile.RestApi
                 JwtBearerDefaults.AuthenticationScheme)
                 .AddJwtBearer(options =>
                 {
-                    options.Authority = "https://dev-7862904.okta.com/oauth2/default";
+                    options.Authority = "https://dev-2875280.okta.com/oauth2/default";
                     options.Audience = "api://default";
 
                     // Won't send details outside of dev env

--- a/Fakebook.Profile/Fakebook.Profile.RestApi/Startup.cs
+++ b/Fakebook.Profile/Fakebook.Profile.RestApi/Startup.cs
@@ -1,4 +1,5 @@
 using System.IO;
+
 using Azure.Storage.Blobs;
 using Fakebook.Profile.DataAccess.EntityModel;
 using Fakebook.Profile.DataAccess.Services;
@@ -56,7 +57,7 @@ namespace Fakebook.Profile.RestApi
             services.AddDbContext<ProfileDbContext>(options
                 => options.UseNpgsql(Configuration.GetConnectionString("FakebookProfile")));
 
-            var blobContainerName = Configuration["ProfileConfig:BlobContainer"];
+            var blobContainerName = Configuration[ProfileConfigOptions.ProfileConfig];
 
             // for azure blob
             services.AddTransient<IStorageService, AzureBlobStorageService>(sp

--- a/Fakebook.Profile/Fakebook.Profile.RestApi/appsettings.Development.json
+++ b/Fakebook.Profile/Fakebook.Profile.RestApi/appsettings.Development.json
@@ -1,9 +1,12 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft": "Warning",
+            "Microsoft.Hosting.Lifetime": "Information"
+        }
+    },
+    "ProfileConfig": {
+        "BlobContainer": "profile-image"
     }
-  }
 }

--- a/Fakebook.Profile/Fakebook.Profile.RestApi/appsettings.json
+++ b/Fakebook.Profile/Fakebook.Profile.RestApi/appsettings.json
@@ -9,8 +9,8 @@
             "Microsoft.Hosting.Lifetime": "Information"
         }
     },
-    "AllowedHosts": "*",
     "ProfileConfig": {
         "BlobContainer": "profile-image"
-    }
+    },
+    "AllowedHosts": "*"
 }


### PR DESCRIPTION
Previously the okta link was to the wrong okta setup, and the container name wasn't being accessed correctly in the ProfilePictureController, so this is a fix to that, by getting the name using configuration.