### PR TITLE
Await for the context results so it doesn't synchronously pass over it

### DIFF
--- a/Fakebook.Profile/Fakebook.Profile.Domain/ProfileRepository.cs
+++ b/Fakebook.Profile/Fakebook.Profile.Domain/ProfileRepository.cs
@@ -106,19 +106,16 @@ namespace Fakebook.Profile.Domain
                 throw new ArgumentException("Source is empty", nameof(entities));
             }
 
-            var profileFound = _context.EntityProfiles
+            var profile = await _context.EntityProfiles
                 .FirstOrDefaultAsync(x => x.Email == email);
 
-            if (profileFound == null)
+            if (profile == null)
             {
                 throw new ArgumentNullException("Email not found", nameof(email));
             }
 
-            var entity = await entities
-                .FirstOrDefaultAsync(e => e.Email == email);
-
             // model mapping
-            var user = ToDomainProfile(entity);
+            var user = ToDomainProfile(profile);
             return user;
         }
 


### PR DESCRIPTION
The get method didn't await for the results, and it causes an error, returning a 500. This fixes that by awaiting the changes, and also removed the redundant call to get the first entity that matches the email.