### PR TITLE
Fix to the different casings on emails

### DIFF
--- a/Fakebook.Profile/Fakebook.Profile.Domain/ProfileRepository.cs
+++ b/Fakebook.Profile/Fakebook.Profile.Domain/ProfileRepository.cs
@@ -107,7 +107,7 @@ namespace Fakebook.Profile.Domain
             }
 
             var profile = await _context.EntityProfiles
-                .FirstOrDefaultAsync(x => x.Email.ToLower() == email.ToLower());
+                .FirstOrDefaultAsync(x => x.Email.ToUpper() == email.ToUpper());
 
             if (profile == null)
             {
@@ -128,10 +128,10 @@ namespace Fakebook.Profile.Domain
         {
             var userEntities = _context.EntityProfiles;
             var userEmails = userEntities
-                .Select(u => u.Email.ToLower())
+                .Select(u => u.Email.ToUpper())
                 .ToList();
 
-            if (!emails.All(e => userEmails.Contains(e.ToLower())))
+            if (!emails.All(e => userEmails.Contains(e.ToUpper())))
             {
                 throw new ArgumentException("Not all emails requested are present.", nameof(emails));
             }
@@ -189,7 +189,7 @@ namespace Fakebook.Profile.Domain
                 }
 
                 var profile = await _context.EntityProfiles
-                    .FirstOrDefaultAsync(x => x.Email.ToLower() == email.ToLower());
+                    .FirstOrDefaultAsync(x => x.Email.ToUpper() == email.ToUpper());
 
                 if (profile == null)
                 {

--- a/Fakebook.Profile/Fakebook.Profile.Domain/ProfileRepository.cs
+++ b/Fakebook.Profile/Fakebook.Profile.Domain/ProfileRepository.cs
@@ -107,7 +107,7 @@ namespace Fakebook.Profile.Domain
             }
 
             var profile = await _context.EntityProfiles
-                .FirstOrDefaultAsync(x => x.Email == email);
+                .FirstOrDefaultAsync(x => x.Email.ToLower() == email.ToLower());
 
             if (profile == null)
             {
@@ -128,10 +128,10 @@ namespace Fakebook.Profile.Domain
         {
             var userEntities = _context.EntityProfiles;
             var userEmails = userEntities
-                .Select(u => u.Email)
+                .Select(u => u.Email.ToLower())
                 .ToList();
 
-            if (!emails.All(e => userEmails.Contains(e)))
+            if (!emails.All(e => userEmails.Contains(e.ToLower())))
             {
                 throw new ArgumentException("Not all emails requested are present.", nameof(emails));
             }
@@ -188,7 +188,9 @@ namespace Fakebook.Profile.Domain
                     throw new ArgumentException("Source is empty", nameof(entities));
                 }
 
-                var profile = await _context.EntityProfiles.FirstOrDefaultAsync(x => x.Email == email);
+                var profile = await _context.EntityProfiles
+                    .FirstOrDefaultAsync(x => x.Email.ToLower() == email.ToLower());
+
                 if (profile == null)
                 {
                     throw new ArgumentNullException("Email not found", nameof(email));

--- a/Fakebook.Profile/Fakebook.Profile.UnitTests/DomainTests/RepositoryTests/CreateTests.cs
+++ b/Fakebook.Profile/Fakebook.Profile.UnitTests/DomainTests/RepositoryTests/CreateTests.cs
@@ -49,7 +49,7 @@ namespace Fakebook.Profile.UnitTests.DomainTests.RepositoryTests
                 var repo = new ProfileRepository(assertionContext);
                 var userInDB = await repo.GetProfileAsync(user.Email);
                 Assert.NotNull(userInDB);
-                Assert.Equal(user.Email.ToUpper(), userInDB.Email);
+                Assert.Equal(user.Email, userInDB.Email);
                 Assert.Equal(user.FirstName, userInDB.FirstName);
                 Assert.Equal(user.LastName, userInDB.LastName);
                 Assert.Equal(user.BirthDate, userInDB.BirthDate);

--- a/Fakebook.Profile/Fakebook.Profile.UnitTests/DomainTests/RepositoryTests/CreateTests.cs
+++ b/Fakebook.Profile/Fakebook.Profile.UnitTests/DomainTests/RepositoryTests/CreateTests.cs
@@ -49,7 +49,7 @@ namespace Fakebook.Profile.UnitTests.DomainTests.RepositoryTests
                 var repo = new ProfileRepository(assertionContext);
                 var userInDB = await repo.GetProfileAsync(user.Email);
                 Assert.NotNull(userInDB);
-                Assert.Equal(user.Email, userInDB.Email);
+                Assert.Equal(user.Email.ToUpper(), userInDB.Email);
                 Assert.Equal(user.FirstName, userInDB.FirstName);
                 Assert.Equal(user.LastName, userInDB.LastName);
                 Assert.Equal(user.BirthDate, userInDB.BirthDate);
@@ -92,7 +92,7 @@ namespace Fakebook.Profile.UnitTests.DomainTests.RepositoryTests
             {
                 var repo = new ProfileRepository(assertionContext);
 
-                var userInDB = await repo.GetProfileAsync(user.Email);
+                var userInDB = await repo.GetProfileAsync(user.Email.ToUpper());
                 Assert.Equal(userInDB.ProfilePictureUrl, user.ProfilePictureUrl);
                 Assert.Equal(userInDB.FirstName, user.FirstName);
                 Assert.Equal(userInDB.LastName, user.LastName);

--- a/Fakebook.Profile/Fakebook.Profile.UnitTests/DomainTests/RepositoryTests/ReadTests.cs
+++ b/Fakebook.Profile/Fakebook.Profile.UnitTests/DomainTests/RepositoryTests/ReadTests.cs
@@ -145,7 +145,7 @@ namespace Fakebook.Profile.UnitTests.DomainTests.RepositoryTests
 
                 // testing the first element
                 var userExpected = users.First();
-                var userActual = usersActual.Single(u => u.Email == userExpected.Email);
+                var userActual = usersActual.Single(u => u.Email == userExpected.Email.ToUpper());
                 Assert.Equal(userExpected.ProfilePictureUrl, userActual.ProfilePictureUrl);
                 Assert.Equal(userExpected.FirstName, userActual.FirstName);
                 Assert.Equal(userExpected.LastName, userActual.LastName);
@@ -155,7 +155,7 @@ namespace Fakebook.Profile.UnitTests.DomainTests.RepositoryTests
 
                 // testing the last element
                 var userLastExpected = users.Last();
-                var userLastActual = usersActual.Single(u => u.Email == userLastExpected.Email);
+                var userLastActual = usersActual.Single(u => u.Email == userLastExpected.Email.ToUpper());
                 Assert.Equal(userLastExpected.ProfilePictureUrl, userLastActual.ProfilePictureUrl);
                 Assert.Equal(userLastExpected.FirstName, userLastActual.FirstName);
                 Assert.Equal(userLastExpected.LastName, userLastActual.LastName);

--- a/Fakebook.Profile/Fakebook.Profile.UnitTests/DomainTests/RepositoryTests/ReadTests.cs
+++ b/Fakebook.Profile/Fakebook.Profile.UnitTests/DomainTests/RepositoryTests/ReadTests.cs
@@ -145,7 +145,7 @@ namespace Fakebook.Profile.UnitTests.DomainTests.RepositoryTests
 
                 // testing the first element
                 var userExpected = users.First();
-                var userActual = usersActual.Single(u => u.Email == userExpected.Email.ToUpper());
+                var userActual = usersActual.Single(u => u.Email == userExpected.Email);
                 Assert.Equal(userExpected.ProfilePictureUrl, userActual.ProfilePictureUrl);
                 Assert.Equal(userExpected.FirstName, userActual.FirstName);
                 Assert.Equal(userExpected.LastName, userActual.LastName);
@@ -155,7 +155,7 @@ namespace Fakebook.Profile.UnitTests.DomainTests.RepositoryTests
 
                 // testing the last element
                 var userLastExpected = users.Last();
-                var userLastActual = usersActual.Single(u => u.Email == userLastExpected.Email.ToUpper());
+                var userLastActual = usersActual.Single(u => u.Email == userLastExpected.Email);
                 Assert.Equal(userLastExpected.ProfilePictureUrl, userLastActual.ProfilePictureUrl);
                 Assert.Equal(userLastExpected.FirstName, userLastActual.FirstName);
                 Assert.Equal(userLastExpected.LastName, userLastActual.LastName);


### PR DESCRIPTION
For emails that are all lowercase, it wasn't a problem, but for emails with capitals in them (whether through ASP.NET Core or stored in the backend), it would not match, and not get the user.