### PR TITLE
make running the app for local development easier.

### DIFF
--- a/Fakebook.Profile/Fakebook.Profile.DataAccess/EntityModel/ProfileDbContext.cs
+++ b/Fakebook.Profile/Fakebook.Profile.DataAccess/EntityModel/ProfileDbContext.cs
@@ -61,9 +61,9 @@ namespace Fakebook.Profile.DataAccess.EntityModel
                 {
                     new EntityProfile
                     {
-                        Email = "david.barnes@revature.net",
-                        FirstName = "David",
-                        LastName = "Barnes",
+                        Email = "john.werner@revature.net",
+                        FirstName = "John",
+                        LastName = "Werner",
                         BirthDate = new DateTime(1994, 6, 30),
                         ProfilePictureUrl = new Uri("https://images.unsplash.com/photo-1489533119213-66a5cd877091"),
                         Status = "deployed my app feeling good about today's presentation"

--- a/Fakebook.Profile/Fakebook.Profile.DataAccess/Migrations/20210330200120_NewSeedData.Designer.cs
+++ b/Fakebook.Profile/Fakebook.Profile.DataAccess/Migrations/20210330200120_NewSeedData.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Fakebook.Profile.DataAccess.EntityModel;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace Fakebook.Profile.DataAccess.Migrations
 {
     [DbContext(typeof(ProfileDbContext))]
-    partial class ProfileDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210330200120_NewSeedData")]
+    partial class NewSeedData
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Fakebook.Profile/Fakebook.Profile.DataAccess/Migrations/20210330200120_NewSeedData.cs
+++ b/Fakebook.Profile/Fakebook.Profile.DataAccess/Migrations/20210330200120_NewSeedData.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Fakebook.Profile.DataAccess.Migrations
+{
+    public partial class NewSeedData : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                schema: "Fakebook",
+                table: "Profile",
+                keyColumn: "Email",
+                keyValue: "david.barnes@revature.net");
+
+            migrationBuilder.InsertData(
+                schema: "Fakebook",
+                table: "Profile",
+                columns: new[] { "Email", "BirthDate", "FirstName", "LastName", "PhoneNumber", "ProfilePictureUrl", "Status" },
+                values: new object[] { "john.werner@revature.net", new DateTime(1994, 6, 30, 0, 0, 0, 0, DateTimeKind.Unspecified), "John", "Werner", null, "https://images.unsplash.com/photo-1489533119213-66a5cd877091", "deployed my app feeling good about today's presentation" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                schema: "Fakebook",
+                table: "Profile",
+                keyColumn: "Email",
+                keyValue: "john.werner@revature.net");
+
+            migrationBuilder.InsertData(
+                schema: "Fakebook",
+                table: "Profile",
+                columns: new[] { "Email", "BirthDate", "FirstName", "LastName", "PhoneNumber", "ProfilePictureUrl", "Status" },
+                values: new object[] { "david.barnes@revature.net", new DateTime(1994, 6, 30, 0, 0, 0, 0, DateTimeKind.Unspecified), "David", "Barnes", null, "https://images.unsplash.com/photo-1489533119213-66a5cd877091", "deployed my app feeling good about today's presentation" });
+        }
+    }
+}

--- a/Fakebook.Profile/Fakebook.Profile.RestApi/Properties/launchSettings.json
+++ b/Fakebook.Profile/Fakebook.Profile.RestApi/Properties/launchSettings.json
@@ -22,7 +22,7 @@
       "dotnetRunMessages": "true",
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "applicationUrl": "https://localhost:44362;http://localhost:54488",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Fakebook.Profile/Fakebook.Profile.RestApi/Startup.cs
+++ b/Fakebook.Profile/Fakebook.Profile.RestApi/Startup.cs
@@ -33,11 +33,23 @@ namespace Fakebook.Profile.RestApi
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddCors(options =>
+            {
+                options.AddDefaultPolicy(
+                    builder =>
+                    {
+                        builder.WithOrigins("http://localhost:4200", "https://fakebook.revaturelabs.com/")
+                            .AllowAnyMethod()
+                            .AllowAnyHeader()
+                            .AllowCredentials();
+                    });
+            });
+
             services.AddAuthentication(
                 JwtBearerDefaults.AuthenticationScheme)
                 .AddJwtBearer(options =>
                 {
-                    options.Authority = "https://dev-2875280.okta.com/oauth2/default";
+                    options.Authority = "https://revature-p3.okta.com/oauth2/default";
                     options.Audience = "api://default";
 
                     // Won't send details outside of dev env

--- a/Fakebook.Profile/Fakebook.Profile.RestApi/appsettings.Development.json
+++ b/Fakebook.Profile/Fakebook.Profile.RestApi/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
     "ConnectionStrings": {
-        "FakebookProfile": "Host=localhost:5433;Database=postgres;Username=postgres;Password=Pass@word"
+        "FakebookProfile": "Host=localhost;Port=5433;Database=postgres;Username=postgres;Password=Pass@word"
     },
     "Logging": {
         "LogLevel": {

--- a/Fakebook.Profile/Fakebook.Profile.RestApi/appsettings.Development.json
+++ b/Fakebook.Profile/Fakebook.Profile.RestApi/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+    "ConnectionStrings": {
+        "FakebookProfile": "Host=localhost:5433;Database=postgres;Username=postgres;Password=Pass@word"
+    },
     "Logging": {
         "LogLevel": {
             "Default": "Information",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   db:
     build:
       context: ./Fakebook.Profile
-      dockerfile: Fakebook.Profile/db.dockerfile
+      dockerfile: db.dockerfile
     image: fakebookprofile-db:latest
     ports:
     - 5433:5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 # run in foreground: `docker-compose up`
 # run in background: `docker-compose up -d`
 # stop in background: `docker-compose down`
-# reset the db volume: `docker-compose down -v`
+# reset the db: `docker-compose down -v && docker-compose build`
 
 services:
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+﻿version: '3'
+
+# run in foreground: `docker-compose up`
+# run in background: `docker-compose up -d`
+# stop in background: `docker-compose down`
+# reset the db volume: `docker-compose down -v`
+
+services:
+  db:
+    build:
+      context: ./Fakebook.Profile
+      dockerfile: Fakebook.Profile/db.dockerfile
+    image: fakebookprofile-db:latest
+    ports:
+    - 5433:5432
+    environment:
+      POSTGRES_PASSWORD: Pass@word
+    volumes:
+    - db-data:/var/lib/postgresql/data
+
+volumes:
+  db-data:


### PR DESCRIPTION
- add docker-compose file for the database. the service itself can be run outside docker.
- replace old okta configuration with new okta configuration (https://revature-p3-admin.okta.com/)
- replace old seed data based on old David account in okta with new John account in okta
- changed launchSettings so `dotnet run` uses the same ports that Visual Studio would: we can't run multiple services if they all want to be on port 5001.

cf. https://github.com/2011-fakebook-project3/ng/pull/65, https://github.com/2011-fakebook-project3/posts/pull/114, https://github.com/2011-fakebook-project3/notifications/pull/47