### PR TITLE
Profile refactor image

### DIFF
--- a/Fakebook.Profile/Fakebook.Profile.RestApi/Controllers/ProfilePictureController.cs
+++ b/Fakebook.Profile/Fakebook.Profile.RestApi/Controllers/ProfilePictureController.cs
@@ -48,7 +48,7 @@ namespace Fakebook.Profile.RestApi.Controllers
         [HttpPost, DisableRequestSizeLimit]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public async Task<ActionResult> uploadProfilePicture()
+        public async Task<ActionResult> UploadProfilePicture()
         {
             IFormFile file = Request.Form.Files[0];
             if (file == null)

--- a/Fakebook.Profile/Fakebook.Profile.RestApi/Controllers/ProfilePictureController.cs
+++ b/Fakebook.Profile/Fakebook.Profile.RestApi/Controllers/ProfilePictureController.cs
@@ -48,7 +48,7 @@ namespace Fakebook.Profile.RestApi.Controllers
         [HttpPost, DisableRequestSizeLimit]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public async Task<ActionResult> Post()
+        public async Task<ActionResult> uploadProfilePicture()
         {
             IFormFile file = Request.Form.Files[0];
             if (file == null)

--- a/Fakebook.Profile/Fakebook.Profile.RestApi/Startup.cs
+++ b/Fakebook.Profile/Fakebook.Profile.RestApi/Startup.cs
@@ -1,6 +1,7 @@
 using System.IO;
 
 using Azure.Storage.Blobs;
+using Fakebook.Profile.DataAccess;
 using Fakebook.Profile.DataAccess.EntityModel;
 using Fakebook.Profile.DataAccess.Services;
 using Fakebook.Profile.DataAccess.Services.Interfaces;

--- a/Fakebook.Profile/Fakebook.Profile.UnitTests/APITests/ProfilePictureControllerTests.cs
+++ b/Fakebook.Profile/Fakebook.Profile.UnitTests/APITests/ProfilePictureControllerTests.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Fakebook.Profile.DataAccess.Services.Interfaces;
+using Fakebook.Profile.Domain;
+using Fakebook.Profile.RestApi.ApiModel;
+using Fakebook.Profile.RestApi.Controllers;
+using Fakebook.Profile.UnitTests.TestData;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Primitives;
+using Moq;
+
+using Xunit;
+
+namespace Fakebook.Profile.UnitTests.APITests
+{
+    public class ProfilePictureControllerTests
+    {
+        [Fact]
+        public async Task uploadValidImageSize()
+        {
+            // arrange
+            Mock<IConfiguration> mockedStorageConfiguration = new();
+            Mock<IStorageService> mockedStorageService = new();
+            mockedStorageService
+                .Setup(x => x.UploadFileContentAsync(It.IsAny<Stream>(), It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>()))
+                .Returns(Task.FromResult(new Uri("https://www.fake.com")));
+            byte[] data = new byte[1000];
+            var stream = new MemoryStream(data);
+            var file = new FormFile(stream, 0, 0, "Data", "dummy.jpeg")
+            {
+                Headers = new HeaderDictionary(),
+                ContentType = "image/jpeg"
+            };
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers.Add("Content-Type", "multipart/form-data");
+            httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>(), new FormFileCollection { file });
+            var controllerContext = new ControllerContext()
+            {
+                HttpContext = httpContext,
+            };
+            var controller = new ProfilePictureController(mockedStorageService.Object, new NullLogger<ProfileController>(), mockedStorageConfiguration.Object)
+            {
+                ControllerContext = controllerContext
+            };
+
+            // act
+            var result = await controller.uploadProfilePicture();
+
+            // assert
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public async Task uploadInvalidImageSize()
+        {
+            // arrange
+            Mock<IConfiguration> mockedStorageConfiguration = new();
+            Mock<IStorageService> mockedStorageService = new();
+            mockedStorageService
+                .Setup(x => x.UploadFileContentAsync(It.IsAny<Stream>(), It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>()))
+                .Returns(Task.FromResult(new Uri("https://www.fake.com")));
+            byte[] data = new byte[2 * 1024 * 1024];
+            var stream = new MemoryStream(data);
+            var file = new FormFile(stream, 0, 1000, "Data", "dummy.jpeg")
+            {
+                Headers = new HeaderDictionary(),
+                ContentType = "image/jpeg"
+            };
+            file.ContentType = "image/jpeg";
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers.Add("Content-Type", "multipart/form-data");
+            httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>(), new FormFileCollection { file });
+            var controllerContext = new ControllerContext()
+            {
+                HttpContext = httpContext,
+            };
+            var controller = new ProfilePictureController(mockedStorageService.Object, new NullLogger<ProfileController>(), mockedStorageConfiguration.Object)
+            {
+                ControllerContext = controllerContext
+            };
+
+            // act
+            var result = await controller.uploadProfilePicture();
+        }
+    }
+}

--- a/Fakebook.Profile/Fakebook.Profile.UnitTests/APITests/ProfilePictureControllerTests.cs
+++ b/Fakebook.Profile/Fakebook.Profile.UnitTests/APITests/ProfilePictureControllerTests.cs
@@ -89,8 +89,8 @@ namespace Fakebook.Profile.UnitTests.APITests
                 ControllerContext = controllerContext
             };
 
-            // act
-            var result = await controller.uploadProfilePicture();
+            // act and assert
+            await Assert.ThrowsAsync<Exception>(() => controller.uploadProfilePicture());
         }
     }
 }

--- a/Fakebook.Profile/Fakebook.Profile.UnitTests/APITests/ProfilePictureControllerTests.cs
+++ b/Fakebook.Profile/Fakebook.Profile.UnitTests/APITests/ProfilePictureControllerTests.cs
@@ -24,7 +24,7 @@ namespace Fakebook.Profile.UnitTests.APITests
     public class ProfilePictureControllerTests
     {
         [Fact]
-        public async Task uploadValidImageSize()
+        public async Task UploadValidImageSize()
         {
             // arrange
             Mock<IConfiguration> mockedStorageConfiguration = new();
@@ -53,14 +53,14 @@ namespace Fakebook.Profile.UnitTests.APITests
             };
 
             // act
-            var result = await controller.uploadProfilePicture();
+            var result = await controller.UploadProfilePicture();
 
             // assert
             Assert.NotNull(result);
         }
 
         [Fact]
-        public async Task uploadInvalidImageSize()
+        public async Task UploadInvalidImageSize()
         {
             // arrange
             Mock<IConfiguration> mockedStorageConfiguration = new();
@@ -90,7 +90,7 @@ namespace Fakebook.Profile.UnitTests.APITests
             };
 
             // act and assert
-            await Assert.ThrowsAsync<Exception>(() => controller.uploadProfilePicture());
+            await Assert.ThrowsAsync<Exception>(() => controller.UploadProfilePicture());
         }
     }
 }

--- a/Fakebook.Profile/Fakebook.Profile.UnitTests/DomainTests/RepositoryTests/CreateTests.cs
+++ b/Fakebook.Profile/Fakebook.Profile.UnitTests/DomainTests/RepositoryTests/CreateTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
-
+using Fakebook.Profile.DataAccess;
 using Fakebook.Profile.DataAccess.EntityModel;
 using Fakebook.Profile.Domain;
 using Fakebook.Profile.UnitTests.TestData;

--- a/Fakebook.Profile/Fakebook.Profile.UnitTests/DomainTests/RepositoryTests/ReadTests.cs
+++ b/Fakebook.Profile/Fakebook.Profile.UnitTests/DomainTests/RepositoryTests/ReadTests.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-
+using Fakebook.Profile.DataAccess;
 using Fakebook.Profile.DataAccess.EntityModel;
 using Fakebook.Profile.Domain;
 using Fakebook.Profile.UnitTests.TestData.ProfileTestData;

--- a/Fakebook.Profile/Fakebook.Profile.UnitTests/DomainTests/RepositoryTests/UpdateTests.cs
+++ b/Fakebook.Profile/Fakebook.Profile.UnitTests/DomainTests/RepositoryTests/UpdateTests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Threading.Tasks;
-
+using Fakebook.Profile.DataAccess;
 using Fakebook.Profile.DataAccess.EntityModel;
 using Fakebook.Profile.Domain;
 using Fakebook.Profile.UnitTests.TestData;


### PR DESCRIPTION
Added controller tests to test the size of adding a profile image. Adding valid image size passes but invalid image size unit test expects an error thrown so fails. 

rename Post => UploadProfilePicture for more clarity.
UploadValidImageSize => test uploading valid image size
UploadInvalidImageSize => test uploading invalid image size