### PR TITLE
fix upload profile image to not be greater than 2 MB

### DIFF
--- a/Fakebook.Profile/Fakebook.Profile.RestApi/Controllers/ProfilePictureController.cs
+++ b/Fakebook.Profile/Fakebook.Profile.RestApi/Controllers/ProfilePictureController.cs
@@ -27,6 +27,7 @@ namespace Fakebook.Profile.RestApi.Controllers
         private readonly IStorageService _storageService;
         private readonly ILogger<ProfileController> _logger;
         private readonly IConfiguration _configuration;
+        private readonly int _maxFileSize;
 
         /// <summary>
         /// Constructor for a new instance of the controller.
@@ -38,11 +39,12 @@ namespace Fakebook.Profile.RestApi.Controllers
             _logger = logger;
             _configuration = configuration;
             _storageService = storageService;
+            _maxFileSize = 2 * 1024 * 1024; // 2 MB
         }
 
         // POST api/ProfilePicture
         /// <summary>
-        /// Endpoint for uploading an image to the service's storage.
+        /// Endpoint for uploading an image to the service's storage. Arbitrary limit of 2 MB.
         /// </summary>
         /// <returns>An Http response.</returns>
         [HttpPost, DisableRequestSizeLimit]
@@ -54,6 +56,12 @@ namespace Fakebook.Profile.RestApi.Controllers
             if (file == null)
             {
                 _logger.LogError("File given to image posting was null.");
+                return BadRequest();
+            }
+
+            if (file.Length > _maxFileSize)
+            {
+                _logger.LogError("File give to image was too large");
                 return BadRequest();
             }
 

--- a/Fakebook.Profile/Fakebook.Profile.RestApi/Controllers/ProfilePictureController.cs
+++ b/Fakebook.Profile/Fakebook.Profile.RestApi/Controllers/ProfilePictureController.cs
@@ -28,6 +28,8 @@ namespace Fakebook.Profile.RestApi.Controllers
         private readonly ILogger<ProfileController> _logger;
         private readonly IConfiguration _configuration;
         private readonly int _maxFileSize;
+        private const int _numMb = 2;
+        private const int _sizeOfByte = 1024;
 
         /// <summary>
         /// Constructor for a new instance of the controller.
@@ -39,7 +41,7 @@ namespace Fakebook.Profile.RestApi.Controllers
             _logger = logger;
             _configuration = configuration;
             _storageService = storageService;
-            _maxFileSize = 2 * 1024 * 1024; // 2 MB
+            _maxFileSize = _numMb * _sizeOfByte * _sizeOfByte;
         }
 
         // POST api/ProfilePicture

--- a/Fakebook.Profile/Fakebook.Profile.UnitTests/APITests/ProfilePictureControllerTests.cs
+++ b/Fakebook.Profile/Fakebook.Profile.UnitTests/APITests/ProfilePictureControllerTests.cs
@@ -56,7 +56,7 @@ namespace Fakebook.Profile.UnitTests.APITests
             var result = await controller.UploadProfilePicture();
 
             // assert
-            Assert.NotNull(result);
+            Assert.IsNotType<BadRequestResult>(await controller.UploadProfilePicture());
         }
 
         [Fact]

--- a/Fakebook.Profile/Fakebook.Profile.UnitTests/APITests/ProfilePictureControllerTests.cs
+++ b/Fakebook.Profile/Fakebook.Profile.UnitTests/APITests/ProfilePictureControllerTests.cs
@@ -34,7 +34,7 @@ namespace Fakebook.Profile.UnitTests.APITests
                 .Returns(Task.FromResult(new Uri("https://www.fake.com")));
             byte[] data = new byte[1000];
             var stream = new MemoryStream(data);
-            var file = new FormFile(stream, 0, 0, "Data", "dummy.jpeg")
+            var file = new FormFile(stream, 0, 1000, "Data", "dummy.jpeg")
             {
                 Headers = new HeaderDictionary(),
                 ContentType = "image/jpeg"
@@ -68,9 +68,9 @@ namespace Fakebook.Profile.UnitTests.APITests
             mockedStorageService
                 .Setup(x => x.UploadFileContentAsync(It.IsAny<Stream>(), It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>()))
                 .Returns(Task.FromResult(new Uri("https://www.fake.com")));
-            byte[] data = new byte[2 * 1024 * 1024];
+            byte[] data = new byte[3 * 1024 * 1024];
             var stream = new MemoryStream(data);
-            var file = new FormFile(stream, 0, 1000, "Data", "dummy.jpeg")
+            var file = new FormFile(stream, 0, 3 * 1024 * 1024, "Data", "dummy.jpeg")
             {
                 Headers = new HeaderDictionary(),
                 ContentType = "image/jpeg"
@@ -90,7 +90,7 @@ namespace Fakebook.Profile.UnitTests.APITests
             };
 
             // act and assert
-            await Assert.ThrowsAsync<Exception>(() => controller.UploadProfilePicture());
+            Assert.IsType<BadRequestResult>(await controller.UploadProfilePicture());
         }
     }
 }


### PR DESCRIPTION
Add check to make sure uploaded images sizes are not greater than 2MB.

UploadInvalidImageSize() => now passing