### PR TITLE
use theory, add more image extensions, make case insensitive

### DIFF
--- a/Fakebook.Profile/Fakebook.Profile.RestApi/Controllers/ProfilePictureController.cs
+++ b/Fakebook.Profile/Fakebook.Profile.RestApi/Controllers/ProfilePictureController.cs
@@ -60,9 +60,10 @@ namespace Fakebook.Profile.RestApi.Controllers
 
             string extension = file.FileName
                     .Split('.')
-                    .Last();
+                    .Last()
+                    .ToUpper();
 
-            var validExtensions = new List<string> { "png", "jpeg", "gif" };
+            var validExtensions = new List<string> { "PNG", "JPEG", "GIF", "JPG", "SVG", "WEBP", "AVIF", "APNG" };
             // validate file extension to be valid image
             if (!validExtensions.Contains(extension))
             {

--- a/Fakebook.Profile/Fakebook.Profile.RestApi/Controllers/ProfilePictureController.cs
+++ b/Fakebook.Profile/Fakebook.Profile.RestApi/Controllers/ProfilePictureController.cs
@@ -63,7 +63,19 @@ namespace Fakebook.Profile.RestApi.Controllers
                     .Last()
                     .ToUpperInvariant();
 
-            var validExtensions = new List<string> { "PNG", "JPEG", "GIF", "JPG", "SVG", "WEBP", "AVIF", "APNG" };
+            var validExtensions = new List<string> { 
+                "PNG", 
+                "JPEG", 
+                "GIF", 
+                "JPG",
+                "JFIF",
+                "PJPEG",
+                "PJP",
+                "SVG", 
+                "WEBP", 
+                "AVIF", 
+                "APNG"
+            };
             // validate file extension to be valid image
             if (!validExtensions.Contains(extension))
             {

--- a/Fakebook.Profile/Fakebook.Profile.RestApi/Controllers/ProfilePictureController.cs
+++ b/Fakebook.Profile/Fakebook.Profile.RestApi/Controllers/ProfilePictureController.cs
@@ -61,7 +61,7 @@ namespace Fakebook.Profile.RestApi.Controllers
             string extension = file.FileName
                     .Split('.')
                     .Last()
-                    .ToUpper();
+                    .ToUpperInvariant();
 
             var validExtensions = new List<string> { "PNG", "JPEG", "GIF", "JPG", "SVG", "WEBP", "AVIF", "APNG" };
             // validate file extension to be valid image

--- a/Fakebook.Profile/Fakebook.Profile.UnitTests/APITests/ProfilePictureControllerTests.cs
+++ b/Fakebook.Profile/Fakebook.Profile.UnitTests/APITests/ProfilePictureControllerTests.cs
@@ -37,37 +37,7 @@ namespace Fakebook.Profile.UnitTests.APITests
         [InlineData("pjp")]
         public async Task UploadValidImageExtension(string extension)
         {
-            // arrange
-            Mock<IConfiguration> mockedStorageConfiguration = new();
-            Mock<IStorageService> mockedStorageService = new();
-            mockedStorageService
-                .Setup(x => x.UploadFileContentAsync(It.IsAny<Stream>(), It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>()))
-                .Returns(Task.FromResult(new Uri("https://www.fake.com")));
-            byte[] data = new byte[1000];
-            var stream = new MemoryStream(data);
-            var file = new FormFile(stream, 0, 1000, "Data", $"dummy.{extension}")
-            {
-                Headers = new HeaderDictionary(),
-                ContentType = "application/octet-stream"
-            };
-
-            var httpContext = new DefaultHttpContext();
-            httpContext.Request.Headers.Add("Content-Type", "octet-stream");
-            httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>(), new FormFileCollection { file });
-            var controllerContext = new ControllerContext()
-            {
-                HttpContext = httpContext,
-            };
-            var controller = new ProfilePictureController(mockedStorageService.Object, new NullLogger<ProfileController>(), mockedStorageConfiguration.Object)
-            {
-                ControllerContext = controllerContext
-            };
-
-            // act
-            var result = await controller.UploadProfilePicture();
-
-            // assert
-            Assert.IsNotType<BadRequestResult>(await controller.UploadProfilePicture());
+            await UploadImageExtension(extension, true);
         }
 
         [Theory]
@@ -75,6 +45,11 @@ namespace Fakebook.Profile.UnitTests.APITests
         [InlineData("xml")]
         [InlineData("bmp")]
         public async Task UploadInvalidImageExtension(string extension)
+        {
+            await UploadImageExtension(extension, false);
+        }
+
+        internal async Task UploadImageExtension(string extension, bool successExpected)
         {
             // arrange
             Mock<IConfiguration> mockedStorageConfiguration = new();
@@ -102,8 +77,19 @@ namespace Fakebook.Profile.UnitTests.APITests
                 ControllerContext = controllerContext
             };
 
-            // act and assert
-            Assert.IsType<BadRequestResult>(await controller.UploadProfilePicture());
+            if (successExpected)
+            {
+                // act
+                var result = await controller.UploadProfilePicture();
+
+                // assert
+                Assert.IsNotType<BadRequestResult>(await controller.UploadProfilePicture());
+            }
+            else
+            {
+                // act and assert
+                Assert.IsType<BadRequestResult>(await controller.UploadProfilePicture());
+            }
         }
     }
 }

--- a/Fakebook.Profile/Fakebook.Profile.UnitTests/APITests/ProfilePictureControllerTests.cs
+++ b/Fakebook.Profile/Fakebook.Profile.UnitTests/APITests/ProfilePictureControllerTests.cs
@@ -23,8 +23,16 @@ namespace Fakebook.Profile.UnitTests.APITests
 {
     public class ProfilePictureControllerTests
     {
-        [Fact]
-        public async Task UploadValidImageExtension()
+        [Theory]
+        [InlineData("jpeg")]
+        [InlineData("png")]
+        [InlineData("gif")]
+        [InlineData("jpg")]
+        [InlineData("svg")]
+        [InlineData("webp")]
+        [InlineData("avif")]
+        [InlineData("apng")]
+        public async Task UploadValidImageExtension(string extension)
         {
             // arrange
             Mock<IConfiguration> mockedStorageConfiguration = new();
@@ -34,10 +42,10 @@ namespace Fakebook.Profile.UnitTests.APITests
                 .Returns(Task.FromResult(new Uri("https://www.fake.com")));
             byte[] data = new byte[1000];
             var stream = new MemoryStream(data);
-            var file = new FormFile(stream, 0, 1000, "Data", "dummy.jpeg")
+            var file = new FormFile(stream, 0, 1000, "Data", $"dummy.{extension}")
             {
                 Headers = new HeaderDictionary(),
-                ContentType = "image/jpeg"
+                ContentType = $"image/{extension}"
             };
 
             var httpContext = new DefaultHttpContext();
@@ -59,8 +67,11 @@ namespace Fakebook.Profile.UnitTests.APITests
             Assert.IsNotType<BadRequestResult>(await controller.UploadProfilePicture());
         }
 
-        [Fact]
-        public async Task UploadInvalidImageExtension()
+        [Theory]
+        [InlineData("json")]
+        [InlineData("xml")]
+        [InlineData("bmp")]
+        public async Task UploadInvalidImageExtension(string extension)
         {
             // arrange
             Mock<IConfiguration> mockedStorageConfiguration = new();
@@ -70,12 +81,11 @@ namespace Fakebook.Profile.UnitTests.APITests
                 .Returns(Task.FromResult(new Uri("https://www.fake.com")));
             byte[] data = new byte[1000];
             var stream = new MemoryStream(data);
-            var file = new FormFile(stream, 0, 1000, "Data", "dummy.json")
+            var file = new FormFile(stream, 0, 1000, "Data", $"dummy.{extension}")
             {
                 Headers = new HeaderDictionary(),
-                ContentType = "image/json"
+                ContentType = $"image/{extension}"
             };
-            file.ContentType = "image/json";
 
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Headers.Add("Content-Type", "multipart/form-data");

--- a/Fakebook.Profile/Fakebook.Profile.UnitTests/APITests/ProfilePictureControllerTests.cs
+++ b/Fakebook.Profile/Fakebook.Profile.UnitTests/APITests/ProfilePictureControllerTests.cs
@@ -66,7 +66,7 @@ namespace Fakebook.Profile.UnitTests.APITests
             };
 
             var httpContext = new DefaultHttpContext();
-            httpContext.Request.Headers.Add("Content-Type", "octet-stream");
+            httpContext.Request.Headers.Add("Content-Type", "multipart/form-data");
             httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>(), new FormFileCollection { file });
             var controllerContext = new ControllerContext()
             {
@@ -77,18 +77,17 @@ namespace Fakebook.Profile.UnitTests.APITests
                 ControllerContext = controllerContext
             };
 
+            // act
+            var result = await controller.UploadProfilePicture();
+
+            // assert
             if (successExpected)
             {
-                // act
-                var result = await controller.UploadProfilePicture();
-
-                // assert
-                Assert.IsNotType<BadRequestResult>(await controller.UploadProfilePicture());
+                Assert.IsAssignableFrom<CreatedResult>(result);
             }
             else
             {
-                // act and assert
-                Assert.IsType<BadRequestResult>(await controller.UploadProfilePicture());
+                Assert.IsAssignableFrom<BadRequestResult>(result);
             }
         }
     }

--- a/Fakebook.Profile/Fakebook.Profile.UnitTests/APITests/ProfilePictureControllerTests.cs
+++ b/Fakebook.Profile/Fakebook.Profile.UnitTests/APITests/ProfilePictureControllerTests.cs
@@ -48,11 +48,11 @@ namespace Fakebook.Profile.UnitTests.APITests
             var file = new FormFile(stream, 0, 1000, "Data", $"dummy.{extension}")
             {
                 Headers = new HeaderDictionary(),
-                ContentType = $"image/{extension}"
+                ContentType = "application/octet-stream"
             };
 
             var httpContext = new DefaultHttpContext();
-            httpContext.Request.Headers.Add("Content-Type", "multipart/form-data");
+            httpContext.Request.Headers.Add("Content-Type", "octet-stream");
             httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>(), new FormFileCollection { file });
             var controllerContext = new ControllerContext()
             {
@@ -87,11 +87,11 @@ namespace Fakebook.Profile.UnitTests.APITests
             var file = new FormFile(stream, 0, 1000, "Data", $"dummy.{extension}")
             {
                 Headers = new HeaderDictionary(),
-                ContentType = $"image/{extension}"
+                ContentType = "application/octet-stream"
             };
 
             var httpContext = new DefaultHttpContext();
-            httpContext.Request.Headers.Add("Content-Type", "multipart/form-data");
+            httpContext.Request.Headers.Add("Content-Type", "octet-stream");
             httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>(), new FormFileCollection { file });
             var controllerContext = new ControllerContext()
             {

--- a/Fakebook.Profile/Fakebook.Profile.UnitTests/APITests/ProfilePictureControllerTests.cs
+++ b/Fakebook.Profile/Fakebook.Profile.UnitTests/APITests/ProfilePictureControllerTests.cs
@@ -32,6 +32,9 @@ namespace Fakebook.Profile.UnitTests.APITests
         [InlineData("webp")]
         [InlineData("avif")]
         [InlineData("apng")]
+        [InlineData("jfif")]
+        [InlineData("pjpeg")]
+        [InlineData("pjp")]
         public async Task UploadValidImageExtension(string extension)
         {
             // arrange


### PR DESCRIPTION
Change to use theory and test more file extensions. Added more extensions that [extensions](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img) seemed to support. Use ToUpperInvariant to make sure testing was case insensitive.